### PR TITLE
Protect from Play Netty NullPointerException when using Http.Request remoteAddress

### DIFF
--- a/play-restli/src/main/java/com/linkedin/playrestli/BaseRestliServerComponent.java
+++ b/play-restli/src/main/java/com/linkedin/playrestli/BaseRestliServerComponent.java
@@ -8,6 +8,7 @@ import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.message.rest.RestStatus;
 import com.linkedin.r2.transport.http.common.HttpProtocolVersion;
 import com.linkedin.r2.transport.http.server.HttpDispatcher;
+import java.lang.NullPointerException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -63,12 +64,19 @@ public abstract class BaseRestliServerComponent<T extends Request> {
    * The remote address saved here is the internal address not client IP.
    * For more information, refer {@link R2Constants#REMOTE_ADDR}
    **/
-  protected static RequestContext createRequestContext(final Http.Request request) {
-    final String remoteAddress = request.remoteAddress();
+  protected static RequestContext create" request) {
     final RequestContext requestContext = new RequestContext();
-    if (remoteAddress != null) {
-      requestContext.putLocalAttr(R2Constants.REMOTE_ADDR, remoteAddress);
+    try {
+      final String remoteAddress = request.remoteAddress();
+
+      if (remoteAddress != null) {
+        requestContext.putLocalAttr(R2Constants.REMOTE_ADDR, remoteAddress);
+      }
+    } catch (NullPointerException ex) {
+      // TODO - remove this protection once Play Netty implementation can guard against the NPE 
+      LOGGER.warn("Caught NPE From play-netty-server when accessing remote address in a Netty Channel");
     }
+    
     requestContext.putLocalAttr(R2Constants.HTTP_PROTOCOL_VERSION, HttpProtocolVersion.parse(request.version()));
     if (request.secure()) {
       request.clientCertificateChain().ifPresent(chain -> {


### PR DESCRIPTION
In some cases, Play Netty Server implementation may handle a request which does not contain the Netty remote address. The Netty documentation (which uses Channel as the underlying implementation) states that remoteAddress can be null.

Play Netty Server also accesses and attempts to use the remoteAddress as if it could never be null, hence some services experience Null Pointer Exceptions.

We should ultimately have Lightbend fix the bug within their implementation and remove this.